### PR TITLE
Add AI Heap page skeleton

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -32,6 +32,7 @@
     "@ai-sdk/openai": "^1.1.9",
     "@aws-sdk/client-s3": "^3.758.0",
     "@aws-sdk/s3-presigned-post": "^3.758.0",
+    "@heroicons/react": "^2.0.18",
     "@hookform/resolvers": "^3.10.0",
     "@next/third-parties": "^15.2.2",
     "@openrouter/ai-sdk-provider": "^0.1.0",

--- a/web/src/app/ai-heap/ai-heap.client.tsx
+++ b/web/src/app/ai-heap/ai-heap.client.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import { AiHeapNode } from "@/types/AiHeapNode";
+import { ChevronDownIcon } from "@heroicons/react/24/solid";
+
+export type AiHeapClientPageProps = {
+  data: AiHeapNode[];
+};
+
+export function AiHeapClientPage({ data }: AiHeapClientPageProps) {
+  return (
+    <div className="flex h-screen flex-col overflow-hidden bg-background">
+      <header className="p-4 text-center text-3xl font-bold">AI Heap</header>
+      <div className="flex-1 overflow-auto p-4">
+        {data.map((node) => (
+          <AiHeapNodeView key={node.id} node={node} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AiHeapNodeView({ node }: { node: AiHeapNode }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="pl-4">
+      <div
+        className="flex cursor-pointer items-center gap-1"
+        onClick={() => setOpen((o) => !o)}
+      >
+        {node.children && (
+          <ChevronDownIcon
+            className={`size-4 transition-transform ${open ? "rotate-0" : "-rotate-90"}`}
+          />
+        )}
+        <span className="font-medium">{node.name}</span>
+      </div>
+      {open && node.children && (
+        <div className="pl-4">
+          {node.children.map((child) => (
+            <AiHeapNodeView key={child.id} node={child} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/ai-heap/page.tsx
+++ b/web/src/app/ai-heap/page.tsx
@@ -1,0 +1,39 @@
+import { type Metadata } from "next";
+import { AiHeapClientPage } from "./ai-heap.client";
+import { type AiHeapNode } from "@/types/AiHeapNode";
+
+export const metadata: Metadata = {
+  title: "AI Heap - AiToolHub",
+};
+
+const exampleData: AiHeapNode[] = [
+  {
+    id: "general",
+    name: "General",
+    category: "general",
+    children: [
+      {
+        id: "openai",
+        name: "OpenAI",
+        category: "general",
+        url: "https://openai.com",
+      },
+    ],
+  },
+  {
+    id: "consumer",
+    name: "Consumer",
+    category: "consumer",
+    children: [
+      {
+        id: "chatgpt",
+        name: "ChatGPT",
+        category: "consumer",
+      },
+    ],
+  },
+];
+
+export default function AiHeapPage() {
+  return <AiHeapClientPage data={exampleData} />;
+}

--- a/web/src/types/AiHeapNode.ts
+++ b/web/src/types/AiHeapNode.ts
@@ -1,0 +1,16 @@
+export type AiHeapCategory =
+  | "general"
+  | "consumer"
+  | "enterprise"
+  | "coding"
+  | "agent"
+  | "benchmarks";
+
+export interface AiHeapNode {
+  id: string;
+  name: string;
+  category: AiHeapCategory;
+  url?: string;
+  image?: string;
+  children?: AiHeapNode[];
+}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -979,6 +979,11 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.9.tgz#50dea3616bc8191fb8e112283b49eaff03e78429"
   integrity sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==
 
+"@heroicons/react@^2.0.18":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-2.2.0.tgz#0c05124af50434a800773abec8d3af6a297d904b"
+  integrity sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==
+
 "@hexagon/base64@^1.1.27":
   version "1.1.28"
   resolved "https://registry.yarnpkg.com/@hexagon/base64/-/base64-1.1.28.tgz#7d306a97f1423829be5b27c9d388fe50e3099d48"


### PR DESCRIPTION
## Summary
- create AiHeapNode type for manual node data
- add AI Heap page with example nodes
- integrate Heroicons and interactive tree view

## Testing
- `yarn lint` *(fails: configuration prompt)*
- `yarn typecheck` *(fails: missing module)*

------
https://chatgpt.com/codex/tasks/task_b_684defaaefa4832e8c68c1dcdca6b872