### PR TITLE
Add AI hierarchy visualization

### DIFF
--- a/web/src/app/ai-heap/ai-heap.client.tsx
+++ b/web/src/app/ai-heap/ai-heap.client.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useState } from "react";
 import { AiHeapNode } from "@/types/AiHeapNode";
-import { ChevronDownIcon } from "@heroicons/react/24/solid";
+import { AiHeapVisualization } from "@/components/AiHeapVisualization";
 
 export type AiHeapClientPageProps = {
   data: AiHeapNode[];
@@ -12,37 +11,7 @@ export function AiHeapClientPage({ data }: AiHeapClientPageProps) {
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-background">
       <header className="p-4 text-center text-3xl font-bold">AI Heap</header>
-      <div className="flex-1 overflow-auto p-4">
-        {data.map((node) => (
-          <AiHeapNodeView key={node.id} node={node} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function AiHeapNodeView({ node }: { node: AiHeapNode }) {
-  const [open, setOpen] = useState(true);
-  return (
-    <div className="pl-4">
-      <div
-        className="flex cursor-pointer items-center gap-1"
-        onClick={() => setOpen((o) => !o)}
-      >
-        {node.children && (
-          <ChevronDownIcon
-            className={`size-4 transition-transform ${open ? "rotate-0" : "-rotate-90"}`}
-          />
-        )}
-        <span className="font-medium">{node.name}</span>
-      </div>
-      {open && node.children && (
-        <div className="pl-4">
-          {node.children.map((child) => (
-            <AiHeapNodeView key={child.id} node={child} />
-          ))}
-        </div>
-      )}
+      <AiHeapVisualization data={data} />
     </div>
   );
 }

--- a/web/src/app/ai-heap/page.tsx
+++ b/web/src/app/ai-heap/page.tsx
@@ -32,6 +32,54 @@ const exampleData: AiHeapNode[] = [
       },
     ],
   },
+  {
+    id: "enterprise",
+    name: "Enterprise",
+    category: "enterprise",
+    children: [
+      {
+        id: "crm",
+        name: "CRM Tools",
+        category: "enterprise",
+      },
+    ],
+  },
+  {
+    id: "coding",
+    name: "Coding",
+    category: "coding",
+    children: [
+      {
+        id: "copilot",
+        name: "GitHub Copilot",
+        category: "coding",
+      },
+    ],
+  },
+  {
+    id: "agent",
+    name: "Agents",
+    category: "agent",
+    children: [
+      {
+        id: "autogpt",
+        name: "AutoGPT",
+        category: "agent",
+      },
+    ],
+  },
+  {
+    id: "benchmarks",
+    name: "Benchmarks",
+    category: "benchmarks",
+    children: [
+      {
+        id: "lmsys",
+        name: "LMSYS",
+        category: "benchmarks",
+      },
+    ],
+  },
 ];
 
 export default function AiHeapPage() {

--- a/web/src/components/AiHeapVisualization.tsx
+++ b/web/src/components/AiHeapVisualization.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import { AiHeapNode } from "@/types/AiHeapNode";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  ChevronDownIcon,
+  GlobeAltIcon,
+  UserIcon,
+  BuildingOffice2Icon,
+  CodeBracketIcon,
+  SparklesIcon,
+  PresentationChartBarIcon,
+} from "@heroicons/react/24/solid";
+import { cn } from "@/lib/utils";
+
+const iconMap = {
+  general: GlobeAltIcon,
+  consumer: UserIcon,
+  enterprise: BuildingOffice2Icon,
+  coding: CodeBracketIcon,
+  agent: SparklesIcon,
+  benchmarks: PresentationChartBarIcon,
+} as const;
+
+export type AiHeapVisualizationProps = {
+  data: AiHeapNode[];
+};
+
+export function AiHeapVisualization({ data }: AiHeapVisualizationProps) {
+  return (
+    <div className="h-full w-full overflow-auto p-4">
+      {data.map((node) => (
+        <AiHeapNodeView key={node.id} node={node} depth={0} />
+      ))}
+    </div>
+  );
+}
+
+type AiHeapNodeViewProps = {
+  node: AiHeapNode;
+  depth: number;
+};
+
+function AiHeapNodeView({ node, depth }: AiHeapNodeViewProps) {
+  const [open, setOpen] = useState(true);
+  const Icon = iconMap[node.category] ?? SparklesIcon;
+  return (
+    <div className="pl-4">
+      <motion.div
+        whileHover={{ scale: 1.02 }}
+        className={cn(
+          "mb-2 flex cursor-pointer items-center gap-2 rounded-md bg-secondary p-3 text-base font-medium",
+          depth === 0 && "bg-primary text-primary-foreground text-lg"
+        )}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <Icon className="size-5" />
+        <span className="flex-1">{node.name}</span>
+        {node.children && (
+          <ChevronDownIcon
+            className={cn(
+              "size-4 transition-transform",
+              open ? "rotate-0" : "-rotate-90"
+            )}
+          />
+        )}
+      </motion.div>
+      <AnimatePresence initial={false}>
+        {open && node.children && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            className="overflow-hidden pl-4"
+          >
+            {node.children.map((child) => (
+              <AiHeapNodeView key={child.id} node={child} depth={depth + 1} />
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement interactive hierarchy component with Hero icons
- wire up full-screen view in AI Heap page
- expand mock data to show more categories

## Testing
- `CI=true yarn lint` *(fails: Next.js ESLint not configured)*
- `yarn typecheck` *(fails: Module has no exported member error)*
- `yarn format:check` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_b_684df39a1348832e9f3d08d476aa6442