### PR TITLE
Add AI Heap node detail modal

### DIFF
--- a/web/src/components/AiHeapVisualization.tsx
+++ b/web/src/components/AiHeapVisualization.tsx
@@ -13,6 +13,7 @@ import {
   PresentationChartBarIcon,
 } from "@heroicons/react/24/solid";
 import { cn } from "@/lib/utils";
+import { NodeDetailModal } from "./NodeDetailModal";
 
 const iconMap = {
   general: GlobeAltIcon,
@@ -28,21 +29,35 @@ export type AiHeapVisualizationProps = {
 };
 
 export function AiHeapVisualization({ data }: AiHeapVisualizationProps) {
+  const [selected, setSelected] = useState<string | null>(null);
   return (
-    <div className="h-full w-full overflow-auto p-4">
-      {data.map((node) => (
-        <AiHeapNodeView key={node.id} node={node} depth={0} />
-      ))}
-    </div>
+    <>
+      <div className="h-full w-full overflow-auto p-4">
+        {data.map((node) => (
+          <AiHeapNodeView
+            key={node.id}
+            node={node}
+            depth={0}
+            onNodeClick={(id) => setSelected(id)}
+          />
+        ))}
+      </div>
+      <NodeDetailModal
+        nodeId={selected}
+        open={selected !== null}
+        onOpenChange={(o) => !o && setSelected(null)}
+      />
+    </>
   );
 }
 
 type AiHeapNodeViewProps = {
   node: AiHeapNode;
   depth: number;
+  onNodeClick: (id: string) => void;
 };
 
-function AiHeapNodeView({ node, depth }: AiHeapNodeViewProps) {
+function AiHeapNodeView({ node, depth, onNodeClick }: AiHeapNodeViewProps) {
   const [open, setOpen] = useState(true);
   const Icon = iconMap[node.category] ?? SparklesIcon;
   return (
@@ -51,17 +66,21 @@ function AiHeapNodeView({ node, depth }: AiHeapNodeViewProps) {
         whileHover={{ scale: 1.02 }}
         className={cn(
           "mb-2 flex cursor-pointer items-center gap-2 rounded-md bg-secondary p-3 text-base font-medium",
-          depth === 0 && "bg-primary text-primary-foreground text-lg"
+          depth === 0 && "bg-primary text-lg text-primary-foreground",
         )}
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => onNodeClick(node.id)}
       >
         <Icon className="size-5" />
         <span className="flex-1">{node.name}</span>
         {node.children && (
           <ChevronDownIcon
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen((o) => !o);
+            }}
             className={cn(
               "size-4 transition-transform",
-              open ? "rotate-0" : "-rotate-90"
+              open ? "rotate-0" : "-rotate-90",
             )}
           />
         )}
@@ -75,7 +94,12 @@ function AiHeapNodeView({ node, depth }: AiHeapNodeViewProps) {
             className="overflow-hidden pl-4"
           >
             {node.children.map((child) => (
-              <AiHeapNodeView key={child.id} node={child} depth={depth + 1} />
+              <AiHeapNodeView
+                key={child.id}
+                node={child}
+                depth={depth + 1}
+                onNodeClick={onNodeClick}
+              />
             ))}
           </motion.div>
         )}
@@ -83,4 +107,3 @@ function AiHeapNodeView({ node, depth }: AiHeapNodeViewProps) {
     </div>
   );
 }
-

--- a/web/src/components/NodeDetailModal.tsx
+++ b/web/src/components/NodeDetailModal.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import { api } from "@/trpc/react";
+import { AiHeapNode } from "@/types/AiHeapNode";
+
+export type NodeDetailModalProps = {
+  nodeId: string | null;
+  open: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+function findNode(
+  nodes: AiHeapNode[],
+  id: string,
+  path: AiHeapNode[] = [],
+): { node: AiHeapNode; path: AiHeapNode[] } | null {
+  for (const n of nodes) {
+    if (n.id === id) return { node: n, path: [...path, n] };
+    if (n.children) {
+      const res = findNode(n.children, id, [...path, n]);
+      if (res) return res;
+    }
+  }
+  return null;
+}
+
+export function NodeDetailModal({
+  nodeId,
+  open,
+  onOpenChange,
+}: NodeDetailModalProps) {
+  const query = api.aiHeap.getAll.useQuery(undefined, {
+    enabled: open && !!nodeId,
+  });
+
+  const details = useMemo(() => {
+    if (!query.data || !nodeId) return null;
+    return findNode(query.data.nodes, nodeId);
+  }, [query.data, nodeId]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        {query.isPending ? (
+          <div className="space-y-2">
+            <Skeleton className="h-6 w-1/2" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-full" />
+          </div>
+        ) : query.isError ? (
+          <div className="text-destructive">Failed to load node.</div>
+        ) : details ? (
+          <div className="space-y-3">
+            <DialogHeader>
+              <DialogTitle>{details.node.name}</DialogTitle>
+              <DialogDescription>{details.node.category}</DialogDescription>
+            </DialogHeader>
+            {details.node.metadata && (
+              <pre className="whitespace-pre-wrap text-sm">
+                {JSON.stringify(details.node.metadata, null, 2)}
+              </pre>
+            )}
+            <div className="text-sm text-muted-foreground">
+              Position: {details.path.map((p) => p.name).join(" > ")}
+            </div>
+          </div>
+        ) : (
+          <div>Node not found.</div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- enable modal view for AI Heap nodes
- create `NodeDetailModal` for dynamic detail display
- trigger modal from node click and handle expansion separately

## Testing
- `yarn lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_b_684f1da74afc832e9ea08404eb270dc8