### PR TITLE
Enable realtime search updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
 ## Unreleased
+
 - Added clarifying questions to search when confidence is low.
 - Added Vitest tests for the clarify flow.
+- Search results now update in real time during conversations without reloading the page.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ python scraper/find_ai.py
 
 The search interface now asks short clarifying questions when it is unsure about a query. If similarity confidence is below 50%, a question generated with OpenAI's GPT-4o model appears above the results. Answering it refines the search and improves the tools shown.
 
+## Real-Time Results
+
+Search and conversation flow without interruptions. Results now update live as you refine your query so the page never reloads while chatting with the AI assistant.
+
 ## Running Tests
 
 Vitest is used for server-side tests located under `web/src/server/api/routers/__tests__`.

--- a/docs/realtime_search.md
+++ b/docs/realtime_search.md
@@ -1,0 +1,3 @@
+# Real-Time Search Results
+
+Search results now update instantly as you chat with the AI assistant. The page no longer refreshes when you refine your query or adjust filters. Instead, results are fetched in the background and rendered immediately so the conversation remains uninterrupted.

--- a/web/src/app/(admin)/collections/collections.client.tsx
+++ b/web/src/app/(admin)/collections/collections.client.tsx
@@ -13,7 +13,7 @@ export type CollectionsClientPageProps = {};
 
 function CollectionsClientPage({}: CollectionsClientPageProps) {
   const [page, setPage] = useQueryState("page", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => parseInt(v),
   });

--- a/web/src/app/(admin)/searches/searches.client.page.tsx
+++ b/web/src/app/(admin)/searches/searches.client.page.tsx
@@ -29,7 +29,7 @@ export type SearchesClientPageProps = {};
 
 export function SearchesClientPage(props: SearchesClientPageProps) {
   const [page, setPage] = useQueryState("page", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => parseInt(v),
   });

--- a/web/src/app/(admin)/tech-crunch/tech-crunch.client.tsx
+++ b/web/src/app/(admin)/tech-crunch/tech-crunch.client.tsx
@@ -44,7 +44,7 @@ export function TechCrunchClientPage(props: TechCrunchClientPageProps) {
     api.techCrunch.getLatestIngestTimestamps.useQuery();
 
   const [page, setPage] = useQueryState("page", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => parseInt(v),
   });

--- a/web/src/app/(app)/favorites/favorites.client.tsx
+++ b/web/src/app/(app)/favorites/favorites.client.tsx
@@ -10,7 +10,7 @@ const PAGE_SIZE = 18;
 
 export function FavoriteClientPage(props: FavoriteClientPageProps) {
   const [page, setPage] = useQueryState("page", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => parseInt(v),
     defaultValue: 1,

--- a/web/src/app/(app)/search/_components/search-box.tsx
+++ b/web/src/app/(app)/search/_components/search-box.tsx
@@ -53,12 +53,12 @@ export function SearchBox({
   const conversationInitialized = useRef(false);
 
   const [tags, setTags] = useQueryState("tags", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => v.split(",").filter((v) => v.length > 0),
   });
   const [page, setPage] = useQueryState("page", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => parseInt(v),
   });

--- a/web/src/app/(app)/search/_components/search-options.tsx
+++ b/web/src/app/(app)/search/_components/search-options.tsx
@@ -12,12 +12,12 @@ import { useQueryState } from "nuqs";
 
 export function SearchOptions() {
   const [page, setPage] = useQueryState("page", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => parseInt(v),
   });
   const [orderBy, setOrderBy] = useQueryState("orderBy", {
-    shallow: false,
+    shallow: true,
     history: "push",
   });
   return (

--- a/web/src/app/(app)/tools/[id]/tools.client.tsx
+++ b/web/src/app/(app)/tools/[id]/tools.client.tsx
@@ -73,7 +73,7 @@ export function ToolsClientPage({
 }: ToolsClientPageProps) {
   const router = useRouter();
   const [page, setPage] = useQueryState("page", {
-    shallow: false,
+    shallow: true,
     parse: (v) => parseInt(v),
   });
   const { data: userData } = authClient.useSession();
@@ -218,7 +218,6 @@ export function ToolsClientPage({
                 </a>
               </div>
             </div>
-            
           </div>
 
           {/* Actions */}

--- a/web/src/app/_components/gallery-tool-card.tsx
+++ b/web/src/app/_components/gallery-tool-card.tsx
@@ -26,12 +26,12 @@ function GalleryToolCard({
   const [isFavorited, setIsFavorited] = useState(isFavorite);
 
   const [filterTags, setFilterTags] = useQueryState("tags", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => v.split(",").filter((v) => v.length > 0),
   });
   const [page, setPage] = useQueryState("page", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => parseInt(v),
   });

--- a/web/src/app/_components/search.tsx
+++ b/web/src/app/_components/search.tsx
@@ -24,7 +24,7 @@ export type SearchPageProps = {
 export function SearchPage(props: SearchPageProps) {
   const { query } = useSearch();
   const [tags, setTags] = useQueryState("tags", {
-    shallow: false,
+    shallow: true,
     parse: (v) => v.split(",").filter((v) => v.length > 0),
   });
 
@@ -62,17 +62,17 @@ export function SearchResultsPage({
   
   // Query states for filters and pagination
   const [tags, setTags] = useQueryState("tags", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => v.split(",").filter((v) => v.length > 0),
   });
   const [page, setPage] = useQueryState("page", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => parseInt(v),
   });
   const [pricing, setPricing] = useQueryState("pricing", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => (["free", "paid", "free-paid"].includes(v) ? v : undefined),
   });
@@ -253,7 +253,7 @@ export function SearchResultsPage({
 export function SelectedTags() {
   const router = useRouter();
   const [tags, setTags] = useQueryState("tags", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => v.split(",").filter((v) => v.length > 0),
   });

--- a/web/src/app/_components/tool-card.tsx
+++ b/web/src/app/_components/tool-card.tsx
@@ -26,12 +26,12 @@ function ToolCard({
   const [isFavorited, setIsFavorited] = useState(isFavorite);
 
   const [filterTags, setFilterTags] = useQueryState("tags", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => v.split(",").filter((v) => v.length > 0),
   });
   const [page, setPage] = useQueryState("page", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => parseInt(v),
   });

--- a/web/src/components/ui/sidebar/filters-side-bar.tsx
+++ b/web/src/components/ui/sidebar/filters-side-bar.tsx
@@ -31,18 +31,18 @@ function FilterDrawer({}: React.PropsWithChildren<FilterDrawerProps>) {
   const { open, setOpen } = useFilterDrawer();
   const drawerRef = useRef<HTMLDivElement>(null);
   const [tags, setTags] = useQueryState("tags", {
-    shallow: false,
+    shallow: true,
     history: "push",
     defaultValue: [],
     parse: (v) => v.split(",").filter((v) => v.length > 0),
   });
   const [pricing, setPricing] = useQueryState("pricing", {
-    shallow: false,
+    shallow: true,
     history: "push",
     defaultValue: "",
   });
   const [page, setPage] = useQueryState("page", {
-    shallow: false,
+    shallow: true,
     history: "push",
     parse: (v) => parseInt(v),
   });

--- a/web/src/hooks/use-search.ts
+++ b/web/src/hooks/use-search.ts
@@ -2,14 +2,14 @@ import { useQueryState } from "nuqs";
 import { useEffect, useState } from "react";
 
 export function useSearch() {
-  const [query, setQuery] = useQueryState("query", { shallow: false });
+  const [query, setQuery] = useQueryState("query", { shallow: true });
   const [debouncedQuery, setDebouncedQuery] = useState(query);
   const [isSearching, setIsSearching] = useState(false);
 
   // Debounce the search query
   useEffect(() => {
     if (query === debouncedQuery) return;
-    
+
     setIsSearching(true);
     const timer = setTimeout(() => {
       setDebouncedQuery(query);
@@ -26,4 +26,4 @@ export function useSearch() {
     isSearching,
     hasQuery: !!debouncedQuery && debouncedQuery.trim().length > 0,
   };
-} 
+}


### PR DESCRIPTION
## Summary
- keep query parameter updates shallow so the page doesn't refresh
- document new realtime behaviour for search
- update changelog

## Testing
- `npx prettier -w ../CHANGELOG.md ../README.md ../docs/realtime_search.md ...`
- `yarn test` *(fails: Command "test" not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861a0704c24832e90a2c75d8b8a0229